### PR TITLE
Ignore public directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Hugo stuff
 .hugo_build.lock
 **/resources/_gen/
-
+/public
 
 # Apple stuff
 .DS_Store


### PR DESCRIPTION
The public directory is generated and should usually not be committed to the version control system.